### PR TITLE
Fix missing double-quotes giving argparse error

### DIFF
--- a/make_chains.py
+++ b/make_chains.py
@@ -98,7 +98,7 @@ def parse_args():
                                  type=int)
     pipeline_params.add_argument("--chain_linear_gap",
                                  default=Constants.DEFAULT_CHAIN_LINEAR_GAP,
-                                 choices=["loose, medium"],
+                                 choices=["loose", "medium"],
                                  type=str)
     pipeline_params.add_argument("--num_fill_jobs", default=Constants.DEFAULT_NUM_FILL_JOBS, type=int)
     pipeline_params.add_argument("--fill_chain_min_score",


### PR DESCRIPTION
The choices list for optional argument `chain_linear_gap` has a small typo. As a result, it is not possible to correctly specify a valid value for `chain_linear_gap`:

```
make_chains.py: error: argument --chain_linear_gap: invalid choice: 'loose' (choose from 'loose, medium')
```