### PR TITLE
Update nextflow_wrapper.py to fix f string bugs and more

### DIFF
--- a/parallelization/nextflow_wrapper.py
+++ b/parallelization/nextflow_wrapper.py
@@ -27,14 +27,15 @@ class NextflowConfig:
         f = open(self.config_path, "w")
         f.write(f"// Nextflow config for {self.label} jobs\n")
         f.write(f"process.executor = '{self.executor}'\n")
-        f.write("process.memory = { 4.GB * task.attempt }\n")
-        f.write("process.time = {{ {self.time} * task.attempt }}\n")
+        f.write(f"process.memory = {{ {self.memory}.GB * task.attempt }}\n")
+        f.write("process.time = { 0.5.hour*task.attempt }\n")
         f.write(f"process.cpus = '{self.cpus}'\n")
         if self.queue:
             f.write(f"process.queue = '{self.queue}'\n")
         f.write(f"executor.queueSize = '{self.queue_size}'\n")
-        f.write(f"process.maxRetries = 2\n")
-        f.write("process.errorStrategy = { task.exitStatus == 140 ? 'retry' : 'ignore' }\n")
+        f.write("process.maxRetries = 5\n")
+        f.write("process.errorStrategy = 'retry'\n")
+        f.write("process.maxErrors = '-1'\n")
         f.close()
         return self.config_path
 


### PR DESCRIPTION
Hello folks, 

My apologies for the f string bugs again. Now the memory value can be passed properly from the `init` function to the `dump_to_file` function. 

I still have the time hardcoded, because `self.time` will get the value from the `--job_time_req` flag of `make_chains.py`, and it has the slurm time format in my case. So it cannot be used for the `process.time` of Nextflow.

I have changed the `errorStrategy` to always `retry`, not ignoring anything. So every failed child job can get a retry chance.

I changed the allowed total errors accumulated for a given process from the default 100 to no limit, by setting `process. maxErrors` to `-1`. This way the failed child jobs will always get a chance to be retried. Please see here for more info: [https://www.nextflow.io/docs/latest/reference/process.html#maxerrors](https://www.nextflow.io/docs/latest/reference/process.html#maxerrors)

I have tested this new wrapper script on my side, and it's all good. But please help me test this on your side too, just in case.

@NatJWalker-Hale Thanks again!