### PR TITLE
Adding an environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,21 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - python=3
+  - twobitreader
+  - ucsc-twobittofa
+  - ucsc-fatotwobit
+  - ucsc-pslsortacc
+  - ucsc-axtchain
+  - ucsc-chainantirepeat
+  - ucsc-chainmergesort
+  - ucsc-chaincleaner
+  - ucsc-chainsort
+  - ucsc-chainscore
+  - ucsc-chainnet
+  - ucsc-axttopsl
+  - ucsc-chainfilter
+  - lastz
+  - libiconv


### PR DESCRIPTION
I ran into the
```
error while loading shared libraries: libiconv.so.2: cannot open shared object file: No such file or directory
```
error when running chainCleaner manually. I was able to resolve this error by adding the "libiconv" package into my existing conda env. So I think having `libiconv` added as a dependency package would be helpful for others.

On the other hand, the chainCleaner installed from the bioconda channel (version 455) still has the old chromosome size limit bug:
```
chainCleaner: chainCleaner.c:938: newBreak: Assertion breakP->RfillStart >= breakP->suspectEnd' failed.
Aborted (core dumped)
```

And downloading the binaries from [UCSC](http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/) and replace the `chainCleaner` in the `~/miniconda3/envs/your_env/bin/` would fix the above overflow bug. I wasn't able to test this because my OS is too old and I hit the `glibc` error when testing.