### PR TITLE
Remove maxRetries from execute_jobs process

### DIFF
--- a/parallelization/execute_joblist.nf
+++ b/parallelization/execute_joblist.nf
@@ -23,7 +23,6 @@ process execute_jobs {
 
     // allow each process to fail 3 times
     errorStrategy 'retry'
-    maxRetries 3
 
     input:
     val line


### PR DESCRIPTION
Removed maxRetries setting from execute_jobs process. This will override the maxRetries value set in the nextflow_wrapper.py script, so it needs to be removed. I have tested removing this line on my side.