### PR TITLE
Narrowing job arrays down to supporting executors only

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -113,6 +113,16 @@ class Constants:
         CHAIN_RUN_LABEL = "chain_run"
         JOB_MEMORY_REQ = 16  # GB
         DEFAULT_QUEUE_SIZE = 1000
+        # Nextflow executors, grouped by their properties
+        ARRAY_SUPPORTING_EXECS: Tuple[str] = (
+            "awsbatch", 
+            "google-batch",
+            "lsf",
+            "pbs",
+            "pbspro",
+            "sge",
+            "slurm",
+        )
 
     class ToolNames:
         # Kent tools
@@ -132,16 +142,6 @@ class Constants:
         LASTZ = "lastz"
         # very special but necessary executable
         NEXTFLOW = "nextflow"
-        # Nextflow executors, grouped by their properties
-        ARRAY_SUPPORTING_EXECS: Tuple[str] = (
-            "awsbatch", 
-            "google-batch",
-            "lsf",
-            "pbs",
-            "pbspro",
-            "sge",
-            "slurm",
-        )
 
     class ScriptNames:
         REPEAT_FILLER = "chain_gap_filler.py"

--- a/parallelization/nextflow_wrapper.py
+++ b/parallelization/nextflow_wrapper.py
@@ -60,7 +60,7 @@ class NextflowConfig:
             f.write(f"    time = {{ {self.time}.hour * task.attempt }}\n")
             f.write(f"    queue = '{self.queue}'\n")
             f.write(f"    cpus = {self.cpus}\n")
-            if self.job_count > 0 and self.executor in Constants.ToolNames.ARRAY_SUPPORTING_EXECS:
+            if self.job_count > 0 and self.executor in Constants.NextflowConstants.ARRAY_SUPPORTING_EXECS:
                 f.write("   array = 2000\n")
             f.write(f"    maxRetries = {self.maxRetries}\n")
             f.write(f"    errorStrategy = '{self.errorStrategy}'\n")


### PR DESCRIPTION
Attempts to run the pipeline with the `local` executor was reported to crash with the following error:
`ERROR ~ Executor 'local' does not support job arrays`

I cannot reproduce the error with my Nextflow version (20.10.0.5430) but the documentation for 24.0+ (https://www.nextflow.io/docs/latest/reference/process.html) states that only the following executors support the feature:
* [AWS Batch](https://www.nextflow.io/docs/latest/executor.html#awsbatch-executor)
* [Google Cloud Batch](https://www.nextflow.io/docs/latest/executor.html#google-batch-executor)
* [LSF](https://www.nextflow.io/docs/latest/executor.html#lsf-executor)
* [PBS/Torque](https://www.nextflow.io/docs/latest/executor.html#pbs-executor)
* [PBS Pro](https://www.nextflow.io/docs/latest/executor.html#pbspro-executor)
* [SGE](https://www.nextflow.io/docs/latest/executor.html#sge-executor)
* [SLURM](https://www.nextflow.io/docs/latest/executor.html#slurm-executor)

To ensure that the feature is not enabled with other executors, the following snippets were added or modified:  
`constants.py`:
```
106    class NextflowConstants:
107            SCRIPT_LOCATION = os.path.abspath(os.path.dirname(__file__))
108            NF_DIRNAME = "parallelization"
109            NF_DIR = os.path.abspath(os.path.join(SCRIPT_LOCATION, NF_DIRNAME))
110            NF_SCRIPT_PATH = os.path.join(NF_DIR, "execute_joblist.nf")
111            LASTZ_STEP_LABEL = "lastz"
112            FILL_CHAIN_LABEL = "fill_chain"
113            CHAIN_RUN_LABEL = "chain_run"
114           JOB_MEMORY_REQ = 16  # GB
115           DEFAULT_QUEUE_SIZE = 1000
116          # Nextflow executors, grouped by their properties
<<<<<<< HEAD
=======
117         ARRAY_SUPPORTING_EXECS: Tuple[str] = (
118             "awsbatch", 
119             "google-batch",
120             "lsf",
121             "pbs",
122             "pbspro",
123             "sge",
124             "slurm",
125         )
>>>>>>> PR
```
`parallelisation/nextflow_wrapper.py`:
```
<<<<<<< HEAD
63            if self.job_count > 0:
=======
63            if self.job_count > 0 and self.executor in Constants.NextflowConstants.ARRAY_SUPPORTING_EXECS:
>>>>>>> PR
64                f.write("   array = 2000\n")
```