### PR TITLE
Fix/large genome twobit support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,4 +12,4 @@ but a bit better)
 # 2.0.9 (in progress)
 
 - added executor.queueSize parameter to the NF config (default to 1000)
-- Fixed issue #56 (reader side): `run_lastz.py` now extracts `.2bit` partitions to temp FASTA via `py2bit` before calling lastz, since lastz cannot read v1 (64-bit) `.2bit` files produced by `faToTwoBit -long`; temp files written to task work directory instead of `/tmp`
+- Fixed issue #56 (reader side): `run_lastz.py` now extracts `.2bit` partitions to temp FASTA via `twoBitToFa` before calling lastz; `twoBitToFa` supports both v0 and v1/64-bit `.2bit` files (produced by `faToTwoBit -long` for genomes >4 GB), which lastz cannot read directly; removed `py2bit` Python dependency

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,4 +12,4 @@ but a bit better)
 # 2.0.9 (in progress)
 
 - added executor.queueSize parameter to the NF config (default to 1000)
-- Fixed issue #56 (reader side): `run_lastz.py` now extracts `.2bit` partitions to temp FASTA via `twoBitToFa` before calling lastz; `twoBitToFa` supports both v0 and v1/64-bit `.2bit` files (produced by `faToTwoBit -long` for genomes >4 GB), which lastz cannot read directly; removed `py2bit` Python dependency
+- Fixed issue #56: use `twoBitToFa` to extract `.2bit` partitions to temp FASTA before calling lastz (supports v0 and v1/64-bit files); use `twoBitInfo` for chrom name listing and chrom sizes generation; removed `twobitreader`/`py2bit` Python dependencies entirely

--- a/modules/project_setup_procedures.py
+++ b/modules/project_setup_procedures.py
@@ -3,8 +3,6 @@
 import sys
 import os
 import subprocess
-from twobitreader import TwoBitFile
-from twobitreader import TwoBitFileError
 from modules.make_chains_logging import to_log
 from constants import Constants
 from modules.project_paths import ProjectPaths
@@ -14,13 +12,12 @@ from modules.parameters import PipelineParameters
 
 
 def check_if_twobit(genome_seq_file):
-    try:
-        two_bit_reader = TwoBitFile(genome_seq_file)
-        del two_bit_reader
-        return True
-    except TwoBitFileError:
-        # not a twobit, likely a fasta
-        return False
+    result = subprocess.run(
+        ["twoBitInfo", genome_seq_file, "/dev/null"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
 
 
 def check_and_fix_chrom_names(chrom_names, path):
@@ -148,8 +145,13 @@ def setup_genome_sequences(
         # two bit -> if chrom names are intact, just use this file without
         # creating any intermediate files
         # otherwise, create intermediate fasta with fixed chrom names
-        two_bit_reader = TwoBitFile(genome_seq_file)
-        two_bit_chrom_names = list(two_bit_reader.sequence_sizes().keys())
+        result = subprocess.run(
+            ["twoBitInfo", genome_seq_file, "stdout"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+        )
+        two_bit_chrom_names = [
+            line.split("\t")[0] for line in result.stdout.decode().splitlines() if line
+        ]
         invalid_chrom_names = check_and_fix_chrom_names(
             two_bit_chrom_names, genome_seq_file
         )
@@ -210,14 +212,11 @@ def setup_genome_sequences(
     chrom_sizes_filename = f"{label}.chrom.sizes"
     chrom_sizes_path = os.path.join(project_paths.project_dir, chrom_sizes_filename)
 
-    # must be without errors now
-    two_bit_reader = TwoBitFile(seq_dir)
-    twobit_seq_to_size = two_bit_reader.sequence_sizes()
-
-    f = open(chrom_sizes_path, "w")
-    for k, v in twobit_seq_to_size.items():
-        f.write(f"{k}\t{v}\n")
-    f.close()
+    # must be without errors now; write chrom.sizes via twoBitInfo
+    result = subprocess.run(
+        ["twoBitInfo", seq_dir, chrom_sizes_path],
+        stderr=subprocess.PIPE, check=True
+    )
 
     to_log(
         f"For {genome_id} ({label}) sequence file: {seq_dir}; chrom sizes saved to: {chrom_sizes_path}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ authors = [
 ]
 dynamic = ["version"]
 
-dependencies = [
-    "py2bit",
-]
+dependencies = []
 
 [tool.setuptools]
 package-dir = {"" = "."}

--- a/standalone_scripts/run_lastz.py
+++ b/standalone_scripts/run_lastz.py
@@ -13,8 +13,6 @@ import shutil
 import string
 import random
 import json
-import py2bit
-
 __author__ = "Bogdan M. Kirilenko"
 
 
@@ -273,10 +271,16 @@ def parse_seq_arg(arg, tmp_dir, v):
         path_specs_split = elem.split(":")
         path = path_specs_split[0]
         chrom = path_specs_split[1]
-        # extract the chrom sequence from 2bit
-        two_bit_conn = py2bit.open(path)
-        chrom_seq = two_bit_conn.sequence(chrom)
-        f.write(f">{chrom}\n{chrom_seq}\n")
+        # extract the chrom sequence using twoBitToFa (supports v0 and v1/64-bit .2bit)
+        tmp_chrom_fa = os.path.join(tmp_dir, f"{_gen_random_string(8)}_chrom.fa")
+        result = subprocess.run(
+            ["twoBitToFa", f"-seq={chrom}", path, tmp_chrom_fa], stderr=PIPE
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"twoBitToFa failed: {result.stderr.decode()}")
+        with open(tmp_chrom_fa) as fh:
+            f.write(fh.read())
+        os.unlink(tmp_chrom_fa)
     f.close()
     return fasta_path
 
@@ -299,18 +303,19 @@ def check_if_output_is_non_empty(lastz_output):
 
 
 def extract_twobit_partition(two_bit_path, chrom, start, end, tmp_dir):
-    """Extract one partition from a .2bit file to a temp FASTA using py2bit.
+    """Extract one partition from a .2bit file to a temp FASTA using twoBitToFa.
 
     Supports both standard v0 and 64-bit v1 .2bit files (faToTwoBit -long),
-    since lastz only understands v0. py2bit uses 0-based half-open coordinates,
-    matching the start/end values from partition strings.
+    since lastz only understands v0. twoBitToFa uses 0-based half-open
+    coordinates for -start/-end, matching the start/end values from partition strings.
     """
     fasta_path = os.path.join(tmp_dir, f"{_gen_random_string(8)}_partition.fa")
-    tb = py2bit.open(two_bit_path)
-    seq = tb.sequence(chrom, start, end)
-    tb.close()
-    with open(fasta_path, "w") as f:
-        f.write(f">{chrom}\n{seq}\n")
+    result = subprocess.run(
+        ["twoBitToFa", f"-seq={chrom}", f"-start={start}", f"-end={end}", two_bit_path, fasta_path],
+        stderr=PIPE,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"twoBitToFa failed: {result.stderr.decode()}")
     return fasta_path
 
 
@@ -337,7 +342,7 @@ def main():
     query_specs = parse_file_spec(query_seqs)
     v(f"Target specs: {target_specs} | Query specs: {query_specs}")
 
-    # Extract .2bit partitions to temp FASTA via py2bit so lastz never has to
+    # Extract .2bit partitions to temp FASTA via twoBitToFa so lastz never has to
     # read .2bit files directly. This is required for 64-bit v1 .2bit files
     # produced by faToTwoBit -long (large genomes >4 GB), which lastz cannot read.
     if target_specs[1] is not None:


### PR DESCRIPTION
I had two PRs about using py2bit, but after some more testing, I found that py2bit would silently fail without killing the NextFlow pipeline, hence I didn't catch the bug; my apologies. Please see the details below.


## Root cause
**Writer side**: `faToTwoBit` was writing v0 (32-bit) .2bit files, which overflow and abort on sequences >4 GB. Using `faToTwoBit -long` can fix the issue and produce v1 (64-bit) .2bit files.

**Reader side**: `lastz` cannot read v1 (64-bit) .2bit files at all; and the Python `py2bit` or `twobitreader` libraries do not actually support v1 files either. I have submitted an issue to `py2bit` developers: https://github.com/deeptools/py2bit/issues/22


## Fix

1. Add `-long` flag to `faToTwoBit` to produce v1 (64-bit) .2bit files.
2. Replace `py2bit` or `twobitreader` with `twoBitToFa` (UCSC CLI) to extract each partition to a temp FASTA before passing it to `lastz`. 
3. Temp files are written to the Nextflow task work directory rather than `/tmp` to avoid cross-node filesystem issues on SLURM.
4. Let `lastz` use FASTA files instead of .2bit files. 

## Changes

- `modules/local/fa_to_two_bit/main.nf` — add `-long` flag to `faToTwoBit`
- `bin/run_lastz.py` / `standalone_scripts/run_lastz.py` — use `twoBitToFa` subprocess to extract partitions to temp FASTA; remove `py2bit` imports
- `modules/project_setup_procedures.py` — replace `TwoBitFile` with `twoBitInfo` subprocess calls for chrom listing, sizes, and format detection
- `environment.yml`, `pyproject.toml`, `Dockerfile` — remove `py2bit`/`twobitreader` dependencies

## Test plan

- [x] Run pipeline on a genome with total sequence length >4 GB and confirm `.2bit` creation and lastz alignment complete without index overflow or `RuntimeError`
- [x] Confirm `twoBitInfo` and `twoBitToFa` are available in the container/conda env (UCSC tools dependency)
- [x] Run on a standard (<4 GB) genome to confirm no regression
- [x] Verify temp FASTA files are written to the task work dir and cleaned up after each lastz job

Here is the full run I had with a query genome (Rhinatrema bivittatum) at 5.32GBp. I have another test running with a query genome at around 20GBp, I'll report back once it's done. This run finished without bugs, and inside one of its work directories, the temporary fasta files have been deleted.

<img width="1125" height="624" alt="Screenshot 2026-04-07 at 1 43 02 PM" src="https://github.com/user-attachments/assets/fc4bd943-1b85-4910-875c-39aa045d15c3" />

<img width="828" height="404" alt="Screenshot 2026-04-07 at 2 35 29 PM" src="https://github.com/user-attachments/assets/c311d080-ed16-44fe-a842-555664df46c8" />
