### PR TITLE
V3.1.2

### DIFF
--- a/assets/changelog/Changelog.md
+++ b/assets/changelog/Changelog.md
@@ -1,3 +1,19 @@
+# 3.1.2
+
+Introduced a new `chaintools sort` step to sort filled chains before the chain cleaning stage, fixing a `chainNet` error that occurred when unsorted chains reached the cleaning subworkflow.
+
+### New `chaintools sort` module
+
+- Added `modules/local/chaintools/sort/main.nf` — a new process that wraps `chaintools sort` to sort filled chains by score/target/query. The sorted output is now what feeds into the chain cleaning step, preventing the `chainNet` error that previously surfaced when unsorted output from the gap-filling merge reached the cleaner.
+- Integrated `CHAINTOOLS_SORT_MERGED_FILLED_CHAINS` into the `FILL_CLEAN_CHAINS` subworkflow, placed between `CHAINTOOLS_MERGE_FILLED_CHAINS` and the chain cleaning step.
+
+### Config adjustments
+
+- Reassigned the `CHAINTOOLS_MERGE` process label to `process_medium` and disabled its `publishDir` (merged intermediates no longer need to be published) — publication is now handled by `CHAINTOOLS_SORT_MERGED_FILLED_CHAINS`, which also uses `process_medium`.
+- Updated the publish directory pattern for sorted merged chains from `*.all.chain.gz` to `*.chain*` to capture the new sorted chain outputs.
+- Bumped manifest version from `3.1.1` to `3.1.2`.
+
+
 # 3.1.1
 
 Container re-architecture with a new `use_container` parameter that lets users decide between a single whole-pipeline image and granular per-module containers.

--- a/modules/local/chaintools/sort/main.nf
+++ b/modules/local/chaintools/sort/main.nf
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2026 The Hiller Lab at the Senckenberg Gessellschaft für Naturforschung
+Distributed under the terms of the Apache License, Version 2.0.
+*/
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    CHAINTOOLS_SORT — Sort chains by chain score/target/query.
+    Sorts input chains by chain score/target/query according to the 
+    specified sort order. Output is a sorted chain file.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+process CHAINTOOLS_SORT {
+    tag "$chain.baseName"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        '' :
+        'ghcr.io/alejandrogzi/chaintools:latest' }"
+
+    input:
+    tuple val(meta), path(chain)
+
+    output:
+    tuple val(meta), path("*.sorted.chain")       , optional: true, emit: chain
+    tuple val(meta), path("*.sorted.chain.gz")    , optional: true, emit: chain_gz
+    path "versions.yml"                           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args      = task.ext.args ?: ''
+    def prefix    = task.ext.prefix ?: "${chain.baseName}"
+    """
+    chaintools sort \\
+        $args \\
+        --chain $chain \\
+        --threads ${task.cpus} \\
+        --out-chain ${prefix}.sorted.chain
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        chaintools: \$( chaintools --version | sed 's/chaintools //g' )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${chain.baseName}"
+    """
+    touch ${prefix}.sorted.chain
+    touch ${prefix}.sorted.chain.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        chaintools: \$( chaintools --version | sed 's/chaintools //g' )
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ manifest {
     description     = 'Pipeline to create chain-formatted pairwise genome alignments.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=25.04.6'
-    version         = '3.1.1'
+    version         = '3.1.2'
 }
 
 validation {
@@ -176,7 +176,7 @@ process {
 
     withName: '.*:LASTZ' {
         label        = 'process_fast'
-        array        = 500
+        // array        = 500
         beforeScript = 'sleep $((RANDOM % 60))'    // stagger starts to avoid slurm prolog storm
         publishDir   = [
             path: { "${params.outdir}/02_lastz_psl" },
@@ -212,7 +212,7 @@ process {
     withName: '.*:AXT_CHAIN' {
         label     = 'process_medium'
         conda     = "${projectDir}/environment.yml"
-        array     = 500
+        // array     = 500
         publishDir = [
             path: { "${params.outdir}/04_axtchain" },
             mode: 'symlink',
@@ -232,10 +232,15 @@ process {
 
     withName: '.*:CHAINTOOLS_MERGE' {
         label     = 'process_medium'
+        publishDir = [ enabled: false ]
+    }
+
+    withName: '.*:CHAINTOOLS_SORT_MERGED_FILLED_CHAINS' {
+        label     = 'process_medium'
         publishDir = [
             path: { "${params.outdir}/04_axtchain/merged_chains" },
             mode: params.publish_dir_mode,
-            pattern: "*.all.chain.gz"
+            pattern: "*.chain*"
         ]
     }
 
@@ -250,7 +255,7 @@ process {
         cpus      = 1
         memory    = { 24.GB * task.attempt }
         time      = { 1.h   * task.attempt }
-        array     = 500
+        // array     = 500
         publishDir = [ enabled: false ]
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -176,7 +176,7 @@ process {
 
     withName: '.*:LASTZ' {
         label        = 'process_fast'
-        // array        = 500
+        array        = 500
         beforeScript = 'sleep $((RANDOM % 60))'    // stagger starts to avoid slurm prolog storm
         publishDir   = [
             path: { "${params.outdir}/02_lastz_psl" },
@@ -212,7 +212,7 @@ process {
     withName: '.*:AXT_CHAIN' {
         label     = 'process_medium'
         conda     = "${projectDir}/environment.yml"
-        // array     = 500
+        array     = 500
         publishDir = [
             path: { "${params.outdir}/04_axtchain" },
             mode: 'symlink',
@@ -255,7 +255,7 @@ process {
         cpus      = 1
         memory    = { 24.GB * task.attempt }
         time      = { 1.h   * task.attempt }
-        // array     = 500
+        array     = 500
         publishDir = [ enabled: false ]
     }
 

--- a/subworkflows/local/fill_clean_chains/main.nf
+++ b/subworkflows/local/fill_clean_chains/main.nf
@@ -25,6 +25,7 @@ include { CHAINTOOLS_SPLIT  } from '../../../modules/local/chaintools/split/main
 include { CHAINTOOLS_SCORE  } from '../../../modules/local/chaintools/score/main'
 include { CHAINTOOLS_MERGE as CHAINTOOLS_MERGE_FILLED_CHAINS } from '../../../modules/local/chaintools/merge/main'
 include { CHAINTOOLS_FILTER as CHAINTOOLS_FILTER_CLEANED_CHAINS } from '../../../modules/local/chaintools/filter/main'
+include { CHAINTOOLS_SORT as CHAINTOOLS_SORT_MERGED_FILLED_CHAINS } from '../../../modules/local/chaintools/sort/main'
 
 workflow FILL_CLEAN_CHAINS {
     take:
@@ -79,7 +80,11 @@ workflow FILL_CLEAN_CHAINS {
               .map { chains -> [ [ id: reference_name + '.' + query_name + '.filled' ], chains ] }
         )
 
-        ch_chain_for_clean = CHAINTOOLS_MERGE_FILLED_CHAINS.out.chain_gz
+        CHAINTOOLS_SORT_MERGED_FILLED_CHAINS (
+            CHAINTOOLS_MERGE_FILLED_CHAINS.out.chain_gz
+        )
+
+        ch_chain_for_clean = CHAINTOOLS_SORT_MERGED_FILLED_CHAINS.out.chain
 
         ch_versions = ch_versions.mix(CHAINTOOLS_SPLIT.out.versions)
         ch_versions = ch_versions.mix(REPEAT_FILLER.out.versions)


### PR DESCRIPTION
Introduced a new `chaintools sort` step to sort filled chains before the chain cleaning stage, fixing a `chainNet` error that occurred when unsorted chains reached the cleaning subworkflow.

### New `chaintools sort` module

- Added `modules/local/chaintools/sort/main.nf` — a new process that wraps `chaintools sort` to sort filled chains by score/target/query. The sorted output is now what feeds into the chain cleaning step, preventing the `chainNet` error that previously surfaced when unsorted output from the gap-filling merge reached the cleaner.
- Integrated `CHAINTOOLS_SORT_MERGED_FILLED_CHAINS` into the `FILL_CLEAN_CHAINS` subworkflow, placed between `CHAINTOOLS_MERGE_FILLED_CHAINS` and the chain cleaning step.

```
Command error:
  Verbosity level: 1
  foldThreshold: 0.000000    LRfoldThreshold: 2.500000   maxSuspectBases: 2147483647  maxSuspectScore: 100000  minBrokenChainScore: 75000  minLRGapSize: 0 doPairs with LRfoldThreshold: 10.000000   maxPairDistance 10000
  0. need to net the input chains hg38.mm39.filled.all.chain.gz (no net file given) ...
                tempfile for netting: tmp.chainCleaner.XDfdPaF.net
  Got 1 chroms in hg38.chrom.sizes, 1 in mm39.chrom.sizes
  hg38.mm39.filled.all.chain.gz must be sorted in order of score
  ERROR: chainNet failed. Cannot net the chains. Command: chainNet -minScore=0 hg38.mm39.filled.all.chain.gz hg38.chrom.sizes mm39.chrom.sizes tmp.chainCleaner.XDfdPaF.net.raw /dev/null
```

### Config adjustments

- Reassigned the `CHAINTOOLS_MERGE` process label to `process_medium` and disabled its `publishDir` (merged intermediates no longer need to be published) — publication is now handled by `CHAINTOOLS_SORT_MERGED_FILLED_CHAINS`, which also uses `process_medium`.
- Updated the publish directory pattern for sorted merged chains from `*.all.chain.gz` to `*.chain*` to capture the new sorted chain outputs.
- Bumped manifest version from `3.1.1` to `3.1.2`.