### PR TITLE
V3.1.3

### DIFF
--- a/assets/changelog/Changelog.md
+++ b/assets/changelog/Changelog.md
@@ -1,3 +1,35 @@
+# 3.1.3
+
+Refactored the LASTZ alignment wrappers and completed the `target` → `reference` terminology migration across the alignment pipeline, alongside a Python container upgrade and internal code quality improvements.
+
+### LASTZ wrapper rewrite
+
+- Rewrote `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py` with structured logging via Python's `logging` module, comprehensive type annotations, and explicit input validation. The older `verbose_msg` lambda pattern has been replaced with proper `LOGGER.debug()` calls throughout.
+- Migrated both scripts from positional CLI arguments to explicit `--flag value` options (`--reference`, `--query`, `--params_json`, `--output`, etc.), making the command-line interface self-documenting and consistent with the rest of the pipeline's entry points.
+- Added proper resource management — temporary workspace cleanup now uses `try/finally` blocks, ensuring temporary directories are removed even when a subprocess fails.
+- Introduced validated parameter access via `require_string_param` in both scripts, surfacing clear error messages when mandatory pipeline configuration keys are missing or malformed.
+- Added BULK partition validation in `run_lastz_intermediate_layer.py` to catch malformed partition entries early, and replaced `subprocess.call` with `subprocess.run` + `check=True` for immediate error propagation on child failures.
+
+### Terminology completion (`target` → `reference`)
+
+- Renamed the `--target` CLI argument to `--reference` and `--target_chrom_dir` to `--reference_chrom_dir` in both `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py`, including all associated variables, function parameters, and documentation strings.
+- Updated `modules/local/lastz/main.nf` to use `reference_part`, `reference_twobit`, `reference_chrom_sizes`, and `reference_chroms_dir` throughout, and aligned the underlying `run_lastz*` script invocations with the new `--reference` and `--reference_chrom_dir` flags.
+- Harmonised process tags and output channel naming with the new terminology, completing the glossary update that began in v3.1.0.
+
+### Python container upgrade
+
+- Updated the `PARTITION` and `PSL_BUNDLE` process containers from `biocontainers/python:3.8.0--2` to `biocontainers/python:3.11`. Both modules now run on Python 3.11, matching the runtime version used elsewhere in the pipeline.
+
+### Type hints and documentation
+
+- Added full type annotations and docstrings to `bin/partition.py` and `bin/psl_bundle.py` — function signatures now declare argument and return types, constants carry explicit type declarations, and every public function includes a descriptive docstring.
+- Added script-level metadata (`__author__`, `__credits__`, `__email__`, `__github__`, `__version__`) to `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py`.
+
+### Config adjustments
+
+- Bumped manifest version from `3.1.2` to `3.1.3`.
+
+
 # 3.1.2
 
 Introduced a new `chaintools sort` step to sort filled chains before the chain cleaning stage, fixing a `chainNet` error that occurred when unsorted chains reached the cleaning subworkflow.

--- a/bin/partition.py
+++ b/bin/partition.py
@@ -18,15 +18,16 @@ from collections import defaultdict
 
 
 # ── Constants (matching constants.py) ──────────────────────────────────────
-LASTZ_OUT_BUCKET_PREFIX = "bucket_ref"
-LASTZ_OUT_BULK_PREFIX = "bucket_ref_bulk"
-PART_BULK_FILENAME_PREFIX = "BULK"
-MAX_CHROM_IN_BULK = 100
-CHUNK_SIZE_FRACTION_FOR_LITTLE_CHROMOSOMES = 0.75
+LASTZ_OUT_BUCKET_PREFIX: str = "bucket_ref"
+LASTZ_OUT_BULK_PREFIX: str = "bucket_ref_bulk"
+PART_BULK_FILENAME_PREFIX: str = "BULK"
+MAX_CHROM_IN_BULK: int = 100
+CHUNK_SIZE_FRACTION_FOR_LITTLE_CHROMOSOMES: float = 0.75
 
 
 # ── Core logic (inlined from modules/common.py and steps_implementations/partition.py) ─
-def read_chrom_sizes(path):
+def read_chrom_sizes(path: str) -> dict[str, int]:
+    """Read chromosome lengths from a tab-separated chrom.sizes file."""
     sizes = {}
     with open(path) as f:
         for line in f:
@@ -35,7 +36,9 @@ def read_chrom_sizes(path):
     return sizes
 
 
-def create_partition(chrom_sizes, chunk_size, overlap):
+def create_partition(
+    chrom_sizes: dict[str, int], chunk_size: int, overlap: int
+) -> tuple[list[tuple[str, int, int]], list[tuple[str, int]]]:
     """Split chromosomes into overlapping chunks; collect small scaffolds separately.
 
     Note: the old make_chains.py accepted --seq1_limit / --seq2_limit flags to filter
@@ -60,7 +63,9 @@ def create_partition(chrom_sizes, chunk_size, overlap):
     return partition_list, little_scaffolds
 
 
-def create_buckets_for_little_scaffolds(little_scaffolds, chunk_size):
+def create_buckets_for_little_scaffolds(
+    little_scaffolds: list[tuple[str, int]], chunk_size: int
+) -> defaultdict[int, list[str]]:
     """Group small scaffolds into bulks to avoid excessive LASTZ jobs."""
     bulk_num_to_chroms = defaultdict(list)
     bulk_size_threshold = chunk_size * CHUNK_SIZE_FRACTION_FOR_LITTLE_CHROMOSOMES
@@ -81,7 +86,8 @@ def create_buckets_for_little_scaffolds(little_scaffolds, chunk_size):
     return bulk_num_to_chroms
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for genome partitioning."""
     app = argparse.ArgumentParser(description=__doc__)
     app.add_argument(
         "--chrom_sizes",
@@ -117,7 +123,8 @@ def parse_args():
     return app.parse_args()
 
 
-def main():
+def main() -> None:
+    """Write regular and bulk LASTZ partition entries."""
     args = parse_args()
     chrom_sizes = read_chrom_sizes(args.chrom_sizes)
     twobit_name = args.twobit_name  # e.g. "target.2bit"

--- a/bin/psl_bundle.py
+++ b/bin/psl_bundle.py
@@ -15,10 +15,11 @@ import os
 import sys
 
 
-MAX_BASES_DEFAULT = 1_000_000
+MAX_BASES_DEFAULT: int = 1_000_000
 
 
-def read_chrom_sizes(path):
+def read_chrom_sizes(path: str) -> dict[str, int]:
+    """Read chromosome lengths from a tab-separated chrom.sizes file."""
     sizes = {}
     with open(path) as f:
         for line in f:
@@ -27,14 +28,20 @@ def read_chrom_sizes(path):
     return sizes
 
 
-def get_input_files(input_dir):
+def get_input_files(input_dir: str) -> dict[str, int]:
     """Return dict of {filename: processed_flag} for .psl files in input_dir."""
     files = {f: 0 for f in os.listdir(input_dir) if f.endswith(".psl")}
     print(f"Found {len(files)} PSL files to bundle", file=sys.stderr)
     return files
 
 
-def execute_bundle(input_dir, bundle_psl_file_list, output_dir, cur_bundle_count):
+def execute_bundle(
+    input_dir: str,
+    bundle_psl_file_list: list[str],
+    output_dir: str,
+    cur_bundle_count: int,
+) -> None:
+    """Concatenate one list of PSL files into a numbered bundle file."""
     output_path = os.path.join(output_dir, f"bundle.{cur_bundle_count}.psl")
     with open(output_path, "w") as outfile:
         for file_path in bundle_psl_file_list:
@@ -43,7 +50,14 @@ def execute_bundle(input_dir, bundle_psl_file_list, output_dir, cur_bundle_count
     print(f"Written bundle {cur_bundle_count} to {output_path}", file=sys.stderr)
 
 
-def bundle_files(input_dir, chrom_size, input_files, output_dir, max_bases):
+def bundle_files(
+    input_dir: str,
+    chrom_size: dict[str, int],
+    input_files: dict[str, int],
+    output_dir: str,
+    max_bases: int,
+) -> int:
+    """Group chromosome PSL files into bundles up to the configured size limit."""
     cur_bases = 0
     bundle_file_list = []
     bundle_file_count = 0
@@ -74,7 +88,8 @@ def bundle_files(input_dir, chrom_size, input_files, output_dir, max_bases):
     return cur_bundle_count
 
 
-def check_unbundled(input_dir, input_files):
+def check_unbundled(input_dir: str, input_files: dict[str, int]) -> None:
+    """Warn about PSL files that were not matched to a chromosome size."""
     for fname, processed in input_files.items():
         if processed == 0:
             print(
@@ -84,7 +99,8 @@ def check_unbundled(input_dir, input_files):
             )
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for PSL bundling."""
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
         "--input_dir",
@@ -111,7 +127,8 @@ def parse_args():
     return ap.parse_args()
 
 
-def main():
+def main() -> None:
+    """Bundle chromosome PSL files according to their chromosome sizes."""
     args = parse_args()
     os.makedirs(args.output_dir, exist_ok=True)
 

--- a/bin/run_lastz.py
+++ b/bin/run_lastz.py
@@ -1,206 +1,177 @@
 #!/usr/bin/env python3
-"""Run lastz.
-
-Replacement for blastz-run-ucsc.
-"""
+"""Run one LASTZ alignment and optionally convert its AXT output to PSL."""
 
 import argparse
+import json
+import logging
 import os
-import sys
-import subprocess
-from subprocess import PIPE
+import random
+import shlex
 import shutil
 import string
-import random
-import json
+import subprocess
+from subprocess import PIPE
+from typing import Sequence
 
-__author__ = "Bogdan M. Kirilenko, Nil Tianchen Mu"
 
+__author__ = "Alejandro Gonzales-Irribarren"
+__credits__ = ["Bogdan M. Kirilenko, Nil Tianchen Mu"]
+__email__ = "alejandrxgzi@gmail.com"
+__github__ = "https://github.com/hillerlab/make_lastz_chains"
+__version__ = "0.0.2"
+
+
+LOGGER = logging.getLogger("run_lastz")
 
 BLASTZ_PREFIX = "lastz_"
 FORMAT_ARG = "--format=axt+"
 ALLOC_ARG = "--traceback=800.0M"
 
-"""Run lastz example:
-/beegfs/software/lastz/lastz-1.04.15/lastz tParts/part000.2bit[multiple] /tmp/blastz.asiAtt/part000.2bit 
-K=2400 H=2000 L=3000 Y=9400  --format=axt+ > /tmp/blastz.asiAtt/little.raw
-
-Run blastz-run-ucsc example:
-blastz-run-ucsc
--outFormat psl
-/Users/krlnk/Developer/chains_builder/quick_test/hg38.chrM.2bit:chrM:0-500
-/Users/krlnk/Developer/chains_builder/quick_test/mm10.chrM.2bit:chrM:0-15000
-../DEF
-/Users/krlnk/Developer/chains_builder/temp/TEMP_psl/hg38.chrM.2bit:chrM:0-5000/
-    hg38.chrM.2bit:chrM:0-5000_mm10.chrM.2bit:chrM:0-15000.psl
-
-Example command tested on macBook:
-lastz "quick_test/hg38.chrM.2bit/chrM[100,5000][multiple]" 
-"quick_test/mm10.chrM.2bit/chrM[100,5000][multiple]"
---format=axt+ K=2400 H=2000 L=3000 Y=9400
-
-Just need to call this and that's all, no need for temp input files I guess
-
-Bogdan: probably it makes sense to also add
---allocate=800M
-"""
+FileSpec = tuple[str, str | None, int | None, int | None]
+PipelineParams = dict[str, object]
 
 
 class LastzProcessError(Exception):
-    """Must be standalone and run in the nextflow env: easier to define it here."""
-
-    pass
+    """Report a failed LASTZ-related subprocess."""
 
 
-def _gen_random_string(n):
+def configure_logging(verbose: bool) -> None:
+    """Enable concise stderr diagnostics when verbose logging is requested."""
+    logging.basicConfig(format="%(levelname)s %(name)s: %(message)s")
+    LOGGER.setLevel(logging.DEBUG if verbose else logging.WARNING)
+
+
+def _gen_random_string(length: int) -> str:
+    """Return a cryptographically strong random uppercase identifier."""
     return "".join(
         random.SystemRandom().choice(string.ascii_uppercase + string.digits)
-        for _ in range(n)
+        for _ in range(length)
     )
 
 
-def print_err(msg):
-    sys.stderr.write(msg)
-    sys.stderr.write("\n")
-
-
-def parse_args():
-    """Parse arguments."""
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the explicit single-alignment wrapper command-line interface."""
     app = argparse.ArgumentParser()
-    app.add_argument("target", help="Target: single sequence file or .lst")
-    app.add_argument("query", help="Query: single sequence file or .lst")
-    app.add_argument("params_json", help="pipeline configuration file")
-    app.add_argument("output", help="Output file location")
-
     app.add_argument(
-        "--output_format", choices=["psl", "axt"], help="Output format axt|psl"
+        "--reference", required=True, help="Reference sequence file or .lst"
+    )
+    app.add_argument("--query", required=True, help="Query sequence file or .lst")
+    app.add_argument(
+        "--params_json", required=True, help="Pipeline configuration JSON file"
+    )
+    app.add_argument("--output", required=True, help="Output file location")
+    app.add_argument(
+        "--output_format",
+        required=True,
+        choices=["psl", "axt"],
+        help="Output format: axt or psl",
     )
     app.add_argument(
         "--temp_dir",
-        help="Temp directory to save intermediate fasta files (if needed)\n"
-        "/tmp/ is default, however, params_json key TMPDIR can provide a value"
-        "the command line argument has a higher priority than DEF file",
+        help="Optional parent directory for temporary wrapper workspaces",
     )
     app.add_argument(
         "--verbose",
         "-v",
         action="store_true",
-        dest="verbose",
-        help="Show verbosity messages",
+        help="Log wrapper decisions and subprocess commands to stderr",
     )
     app.add_argument(
         "--axt_to_psl",
         default="axtToPsl",
-        help="If axtToPst is not in the path, use this"
-        "argument to provide path to this binary, if needed",
+        help="Path to axtToPsl if it is not available on PATH",
     )
     app.add_argument(
-        "--target_chrom_dir",
+        "--reference_chrom_dir",
         default=None,
-        help="Optional directory of pre-extracted <chrom>.fa files for the target genome. "
-        "When set, the v1 path uses these instead of extracting per-task. "
-        "Empty / non-existent dir → fall back to per-task extraction.",
+        help="Optional directory of pre-extracted <chrom>.fa files for the reference genome",
     )
     app.add_argument(
         "--query_chrom_dir",
         default=None,
-        help="Optional directory of pre-extracted <chrom>.fa files for the query genome.",
+        help="Optional directory of pre-extracted <chrom>.fa files for the query genome",
     )
-
-    if len(sys.argv) < 5:
-        app.print_help()
-        sys.exit(0)
-    args = app.parse_args()
-    return args
+    return app.parse_args(argv)
 
 
-def clean_die(tmp_dir, msg):
-    shutil.rmtree(tmp_dir) if os.path.isdir(tmp_dir) else None
-    sys.stderr.write(f"{msg}\n")
-    sys.exit(1)
+def read_json_file(file_path: str) -> PipelineParams:
+    """Read and validate a pipeline-parameter JSON object."""
+    with open(file_path) as json_file:
+        data = json.load(json_file)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a JSON object in {file_path}")
+    return data
 
 
-def read_json_file(file_path):
-    with open(file_path, "r") as f:
-        return json.load(f)
+def require_string_param(params: PipelineParams, key: str) -> str:
+    """Return a required string parameter with a clear validation error."""
+    value = params.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"Pipeline parameter {key!r} must be a string")
+    return value
 
 
-def read_chrom_sizes(chrom_sizes):
-    """Read chrom.sizes file."""
-    ret = {}
-    f = open(chrom_sizes, "r")
-    for line in f:
-        ld = line.rstrip().split("\t")
-        ret[ld[0]] = int(ld[1])
-    f.close()
-    return ret
+def get_optional_string_param(params: PipelineParams, key: str) -> str | None:
+    """Return an optional string parameter with a clear validation error."""
+    value = params.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Pipeline parameter {key!r} must be a string when provided")
+    return value
 
 
-def get_temp_dir(tmp_dir_param):
-    """Get temp directory."""
-    rnd_suff = _gen_random_string(8)
-    tmp_dirname = f"blastz.{rnd_suff}"
-
-    if tmp_dir_param:
-        if not os.path.isdir(tmp_dir_param):
-            raise ValueError(f"TMPDIR parameter {tmp_dir_param} not a dir")
-        tmp_path = os.path.abspath(os.path.join(tmp_dir_param, tmp_dirname))
-    else:
-        tmp_path = os.path.abspath(os.path.join(".", tmp_dirname))
-    os.mkdir(tmp_path) if not os.path.isdir(tmp_path) else None
-    return tmp_path
+def get_temp_dir(parent_dir: str | None) -> str:
+    """Create and return an owned temporary workspace under a parent directory."""
+    if parent_dir and not os.path.isdir(parent_dir):
+        raise ValueError(f"Temporary parent directory {parent_dir} is not a directory")
+    workspace_parent = parent_dir or "."
+    workspace_path = os.path.abspath(
+        os.path.join(workspace_parent, f"blastz.{_gen_random_string(8)}")
+    )
+    os.mkdir(workspace_path)
+    LOGGER.debug("Created temporary workspace: %s", workspace_path)
+    return workspace_path
 
 
-def define_if_not(dct, key, val):
-    if not dct.get(key):
-        dct[key] = val
-    else:
-        pass
+def define_if_not(params: PipelineParams, key: str, value: object) -> None:
+    """Set a default parameter when the current value is absent or false-like."""
+    if not params.get(key):
+        params[key] = value
 
 
-def get_blastz_params(def_vals):
-    params_lst = []
-    for k, v in def_vals.items():
-        if not k.startswith(BLASTZ_PREFIX):
+def get_blastz_params(params: PipelineParams) -> str:
+    """Translate lastz_* pipeline parameters into LASTZ KEY=value options."""
+    options = []
+    for key, value in params.items():
+        if not key.startswith(BLASTZ_PREFIX):
             continue
-        lastz_key = k.replace(BLASTZ_PREFIX, "").upper()
-        kv_pair = f"{lastz_key}={v}"
-        params_lst.append(kv_pair)
-    params_line = " ".join(params_lst)
-    return params_line
+        lastz_key = key.replace(BLASTZ_PREFIX, "").upper()
+        options.append(f"{lastz_key}={value}")
+    return " ".join(options)
 
 
-def parse_file_spec(filename):
-    """For a given filename return file specifications.
-
-    Such as sequence name (chrom), start and end.
-    """
-    if len(filename.split(":")) == 1:
-        # if no files specs?
-        # this is a collapsed fasta, for instance
+def parse_file_spec(filename: str) -> FileSpec:
+    """Parse a sequence argument into path, chromosome, start, and end fields."""
+    if ":" not in filename:
         return filename, None, None, None
-    base = os.path.basename(filename)
-    path_bare = filename.split(":")[0]
-    _, seq_id, start_end_str = base.split(":")
-    start_end_str_split = start_end_str.split("-")
-    start = int(start_end_str_split[0])
-    end = int(start_end_str_split[1])
+    path_bare = filename.split(":", maxsplit=1)[0]
+    try:
+        _, seq_id, start_end = os.path.basename(filename).split(":")
+        start, end = (int(value) for value in start_end.split("-"))
+    except ValueError as error:
+        raise ValueError(
+            f"Malformed sequence argument {filename!r}: expected <path>:<chrom>:<start>-<end>"
+        ) from error
     return path_bare, seq_id, start, end
 
 
-def _seq_arg(path, chrom, start, end):
-    """Build one lastz sequence argument.
+def _seq_arg(path: str, chrom: str | None, start: int | None, end: int | None) -> str:
+    """Build one LASTZ sequence argument while preserving existing range semantics.
 
-    .2bit:  "<file>/<chrom>[start+1,end][multiple]"  — file/seqname is a
-            .2bit-only selector that uses the .2bit index.
-    FASTA:  "<file>[start+1,end][multiple]"          — file/seqname does NOT
-            work for FASTA (lastz reads it as a literal path and fails). Our
-            v1 path extracts a single chromosome per FASTA via extract_chrom_to_fasta,
-            so the subrange applies unambiguously to that one sequence and lastz
-            emits absolute coordinates the same way it does for .2bit subrange.
-    No subrange given (chrom is None): pass the whole file.
-
-    Subrange indices are 1-based inclusive (lastz convention), hence `start + 1`.
+    The file/sequence selector is valid for .2bit inputs only. Extracted FASTA
+    inputs contain one chromosome, so their ranges apply directly to the file.
+    LASTZ range indices are 1-based inclusive, hence ``start + 1``.
     """
     if chrom is None or start is None or end is None:
         return f'"{path}[multiple]"'
@@ -209,123 +180,117 @@ def _seq_arg(path, chrom, start, end):
     return f'"{path}[{start + 1},{end}][multiple]"'
 
 
-def build_lastz_command(t_specs, q_specs, blastz_options):
-    target_arg = _seq_arg(*t_specs)
-    query_arg = _seq_arg(*q_specs)
-    fields = ("lastz", target_arg, query_arg, blastz_options, ALLOC_ARG, FORMAT_ARG)
+def build_lastz_command(
+    reference_specs: FileSpec,
+    query_specs: FileSpec,
+    blastz_options: str,
+) -> str:
+    """Build the shell command used for one LASTZ invocation."""
+    reference_arg = _seq_arg(*reference_specs)
+    query_arg = _seq_arg(*query_specs)
+    fields = ("lastz", reference_arg, query_arg, blastz_options, ALLOC_ARG, FORMAT_ARG)
     return " ".join(fields)
 
 
-def call_lastz(cmd):
+def call_lastz(command: str) -> str:
+    """Run LASTZ and return decoded AXT output."""
+    LOGGER.debug("Running LASTZ subprocess: %s", command)
     try:
-        lastz_out = subprocess.check_output(
-            cmd, shell=True, stderr=subprocess.PIPE
-        ).decode("utf-8")
-        return lastz_out
-    except subprocess.CalledProcessError as e:
-        error_message = e.stderr.decode("utf-8")
+        return subprocess.check_output(command, shell=True, stderr=PIPE).decode("utf-8")
+    except subprocess.CalledProcessError as error:
+        error_message = error.stderr.decode("utf-8")
         raise LastzProcessError(
-            f"Lastz command failed with exit code {e.returncode}. Error message: {error_message}"
-        )
+            f"LASTZ command failed with exit code {error.returncode}: {error_message}"
+        ) from error
 
 
-def make_psl_if_needed(raw_out, out_format, s1p, s2p, axt_to_psl, v):
-    """Convert lastz output to psl if needed."""
-    if out_format == "axt":
-        return raw_out  # it's already AXT
-    # need to convert to PSL
-    # print(raw_out)
+def make_psl_if_needed(
+    raw_output: str,
+    output_format: str,
+    reference_sizes_path: str,
+    query_sizes_path: str,
+    axt_to_psl: str,
+) -> str:
+    """Return AXT output unchanged or convert it to PSL."""
+    if output_format == "axt":
+        return raw_output
 
-    axt_to_psl_cmd = [axt_to_psl, "/dev/stdin", s1p, s2p, "stdout"]
-    _cmd_plain = " ".join(axt_to_psl_cmd)
-    v(f"Running: {_cmd_plain}")
-    p = subprocess.Popen(axt_to_psl_cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-    stdout_, stderr_ = p.communicate(input=raw_out.encode())
-    stdout = stdout_.decode("utf-8")
-    stderr = stderr_.decode("utf-8")
-    rc = p.returncode
-    if rc != 0:
-        raise LastzProcessError(f"AXTTOPSL COMMAND CRASHED WITH {stderr}")
+    command = [
+        axt_to_psl,
+        "/dev/stdin",
+        reference_sizes_path,
+        query_sizes_path,
+        "stdout",
+    ]
+    LOGGER.debug("Running AXT-to-PSL subprocess: %s", shlex.join(command))
+    process = subprocess.Popen(command, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    stdout_bytes, stderr_bytes = process.communicate(input=raw_output.encode())
+    stdout = stdout_bytes.decode("utf-8")
+    stderr = stderr_bytes.decode("utf-8")
+    if process.returncode != 0:
+        raise LastzProcessError(f"axtToPsl command failed: {stderr}")
     return stdout
 
 
-def parse_seq_arg(arg, tmp_dir, v):
-    """Parse target or query argument.
+def extract_list_to_fasta(list_path: str, tmp_dir: str) -> str:
+    """Collapse a multi-entry .lst file into one temporary FASTA file."""
+    with open(list_path) as list_file:
+        content = [line.rstrip() for line in list_file]
 
-    If it's just a .2bit -> keep it.
-    If a .lst:
-        if single element -> return it
-        if multiple -> merge to a single fasta file.
-    If merged fasta: second ag is True
-    """
-    if not arg.endswith(".lst"):
-        # not a .lst -> just return it
-        v(f"Arg {arg} doesnt end with .lst")
-        return arg
-    v(f"### Arg {arg} ends with lst: collapsing...")
-    with open(arg, "r") as f:
-        # a list of 2bits: need to read it
-        content = [x.rstrip() for x in f.readlines()]
-    num_elems = len(content)
-    if num_elems == 1:
-        # a single element in the list -> return it
-        single_elem = content[0]
-        v(f"List contains a single element: {single_elem}")
-        return single_elem
-    v(f"List contains multiple elements ({num_elems})")
-    # multiple elements
-    # need to collapse them into a single fasta file
-    # then output the path to this temp fasta
-    temp_input_filename = f"{_gen_random_string(8)}_collapsed.fa"
-    fasta_path = os.path.join(tmp_dir, temp_input_filename)
-    v(f"# Saving collapsed fasta to: {fasta_path}")
-
-    f = open(fasta_path, "w")
-    for elem in content:
-        print(f"   # Saving elem: {elem}")
-        path_specs_split = elem.split(":")
-        path = path_specs_split[0]
-        chrom = path_specs_split[1]
-        # extract the chrom sequence using twoBitToFa (supports v0 and v1/64-bit .2bit)
-        tmp_chrom_fa = os.path.join(tmp_dir, f"{_gen_random_string(8)}_chrom.fa")
-        result = subprocess.run(
-            ["twoBitToFa", f"-seq={chrom}", path, tmp_chrom_fa], stderr=PIPE
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"twoBitToFa failed: {result.stderr.decode()}")
-        with open(tmp_chrom_fa) as fh:
-            f.write(fh.read())
-        os.unlink(tmp_chrom_fa)
-    f.close()
+    fasta_path = os.path.join(tmp_dir, f"{_gen_random_string(8)}_collapsed.fa")
+    LOGGER.debug("Saving collapsed FASTA to: %s", fasta_path)
+    with open(fasta_path, "w") as fasta_file:
+        for elem in content:
+            try:
+                path, chrom = elem.split(":")[:2]
+            except ValueError as error:
+                raise ValueError(
+                    f"Malformed .lst entry {elem!r} in {list_path}: expected <path>:<chrom>"
+                ) from error
+            LOGGER.debug("Extracting .lst entry: %s", elem)
+            tmp_chrom_fa = os.path.join(tmp_dir, f"{_gen_random_string(8)}_chrom.fa")
+            command = ["twoBitToFa", f"-seq={chrom}", path, tmp_chrom_fa]
+            LOGGER.debug("Running twoBitToFa subprocess: %s", shlex.join(command))
+            result = subprocess.run(command, stderr=PIPE)
+            if result.returncode != 0:
+                raise RuntimeError(f"twoBitToFa failed: {result.stderr.decode()}")
+            with open(tmp_chrom_fa) as chrom_fasta_file:
+                fasta_file.write(chrom_fasta_file.read())
+            os.unlink(tmp_chrom_fa)
     return fasta_path
 
 
-def check_temp_is_needed(t, q):
-    if t.endswith(".lst") or q.endswith(".lst"):
-        return True
-    return False
+def parse_seq_arg(arg: str, tmp_dir: str | None) -> str:
+    """Resolve a direct sequence argument or collapse a multi-entry .lst file."""
+    if not arg.endswith(".lst"):
+        LOGGER.debug("Sequence argument is not a .lst file: %s", arg)
+        return arg
+
+    LOGGER.debug("Resolving .lst sequence argument: %s", arg)
+    with open(arg) as list_file:
+        content = [line.rstrip() for line in list_file]
+    if len(content) == 1:
+        LOGGER.debug(".lst file contains one element: %s", content[0])
+        return content[0]
+    if tmp_dir is None:
+        raise RuntimeError("A temporary workspace is required to collapse a .lst file")
+    return extract_list_to_fasta(arg, tmp_dir)
 
 
-def verbose_msg(msg):
-    sys.stderr.write(f"{msg}\n")
+def check_temp_is_needed(reference: str, query: str) -> bool:
+    """Return whether either input requires a temporary .lst workspace."""
+    return reference.endswith(".lst") or query.endswith(".lst")
 
 
-def check_if_output_is_non_empty(lastz_output):
-    for line in lastz_output.splitlines():
-        if line and not line.startswith("#"):
-            return True
-    return False
+def check_if_output_is_non_empty(lastz_output: str) -> bool:
+    """Return whether LASTZ output contains a non-comment record."""
+    return any(line and not line.startswith("#") for line in lastz_output.splitlines())
 
 
-def is_2bit_v1(path):
-    """Detect a v1 (64-bit) .2bit file by reading its 8-byte header.
-
-    Layout: 4-byte magic 0x1A412743 followed by 4-byte version field.
-    Version 0 = standard (≤4 GB total); version 1 = 64-bit, written by
-    `faToTwoBit -long` and unreadable by lastz.
-    """
-    with open(path, "rb") as f:
-        header = f.read(8)
+def is_2bit_v1(path: str) -> bool:
+    """Return whether a .2bit file uses the v1 64-bit layout."""
+    with open(path, "rb") as two_bit_file:
+        header = two_bit_file.read(8)
     if header[:4] == b"\x43\x27\x41\x1a":
         version = int.from_bytes(header[4:8], "little")
     elif header[:4] == b"\x1a\x41\x27\x43":
@@ -335,123 +300,101 @@ def is_2bit_v1(path):
     return version == 1
 
 
-def extract_chrom_to_fasta(two_bit_path, chrom, tmp_dir, shared_chrom_dir=None):
-    """Return a FASTA file path containing one whole chromosome.
-
-    Used only for v1 .2bit files (lastz can't read them). The FASTA has a bare
-    ">chrom" header (twoBitToFa default when no -start/-end is given), so
-    lastz subrange syntax on the FASTA produces the same chromosome names
-    and absolute coordinates as native .2bit subrange.
-
-    Two cache layers:
-
-    1. **Shared (preferred):** if `shared_chrom_dir` is set and contains
-       `<chrom>.fa`, return that path directly. The pipeline pre-extracts every
-       chromosome once per genome via the EXTRACT_CHROMS process, then symlinks
-       the directory into every LASTZ task — so all tasks share one extraction.
-
-    2. **Per-task fallback:** if no shared FASTA is available, extract to
-       `./_v1_chrom_cache/` in the current Nextflow work dir. This still
-       deduplicates within a single BULK loop (where the query chrom is
-       repeated across iterations) but not across tasks. Used when the
-       pipeline doesn't supply --target_chrom_dir / --query_chrom_dir
-       (e.g. legacy `make_chains.py` flow).
-    """
-    # Fast path: shared, pre-extracted FASTA.
+def extract_chrom_to_fasta(
+    two_bit_path: str,
+    chrom: str,
+    shared_chrom_dir: str | None = None,
+) -> str:
+    """Return a cached one-chromosome FASTA extracted from a v1 .2bit file."""
     if shared_chrom_dir:
         shared_path = os.path.join(shared_chrom_dir, f"{chrom}.fa")
         if os.path.exists(shared_path):
+            LOGGER.debug("Using shared chromosome FASTA cache: %s", shared_path)
             return shared_path
+        LOGGER.debug("Shared chromosome FASTA cache miss: %s", shared_path)
 
-    # Fallback: per-task cache in the work dir.
     cache_dir = os.path.abspath("./_v1_chrom_cache")
     os.makedirs(cache_dir, exist_ok=True)
-    twobit_basename = os.path.basename(two_bit_path)
-    fasta_path = os.path.join(cache_dir, f"{twobit_basename}_{chrom}.fa")
+    fasta_path = os.path.join(cache_dir, f"{os.path.basename(two_bit_path)}_{chrom}.fa")
     if os.path.exists(fasta_path):
+        LOGGER.debug("Using task-local chromosome FASTA cache: %s", fasta_path)
         return fasta_path
-    result = subprocess.run(
-        ["twoBitToFa", f"-seq={chrom}", two_bit_path, fasta_path],
-        stderr=PIPE,
-    )
+
+    command = ["twoBitToFa", f"-seq={chrom}", two_bit_path, fasta_path]
+    LOGGER.debug("Running twoBitToFa subprocess: %s", shlex.join(command))
+    result = subprocess.run(command, stderr=PIPE)
     if result.returncode != 0:
         raise RuntimeError(f"twoBitToFa failed: {result.stderr.decode()}")
     return fasta_path
 
 
-def main():
-    """Entry point."""
-    args = parse_args()
-    # not orthodox solution but...
-    v = verbose_msg if args.verbose else lambda x: None
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run one LASTZ alignment and append any non-empty output."""
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+    LOGGER.debug("Working directory: %s", os.getcwd())
+    LOGGER.debug("Pipeline params JSON: %s", os.path.abspath(args.params_json))
+
     pipeline_params = read_json_file(args.params_json)
-    seq_1_sizes_path = pipeline_params["seq_1_len"]
-    seq_2_sizes_path = pipeline_params["seq_2_len"]
-    temp_is_needed = check_temp_is_needed(args.target, args.query)
-    # create temp dir iff input contains .lst files
-    tmp_dir = get_temp_dir(pipeline_params.get("temp_dir")) if temp_is_needed else None
-    tmp_dir = args.temp_dir if args.temp_dir else tmp_dir
+    reference_sizes_path = require_string_param(pipeline_params, "seq_1_len")
+    query_sizes_path = require_string_param(pipeline_params, "seq_2_len")
+    temp_parent = args.temp_dir or get_optional_string_param(
+        pipeline_params, "temp_dir"
+    )
+    tmp_dir: str | None = None
 
-    v(f"Temp directory is needed: {temp_is_needed}: {tmp_dir}")
-    target_seqs = parse_seq_arg(args.target, tmp_dir, v)
-    query_seqs = parse_seq_arg(args.query, tmp_dir, v)
-    v(f"Target: {target_seqs} | Query: {query_seqs}")
+    try:
+        if check_temp_is_needed(args.reference, args.query):
+            tmp_dir = get_temp_dir(temp_parent)
+        LOGGER.debug("Temporary workspace: %s", tmp_dir)
 
-    # parse input files ranges (if present)
-    target_specs = parse_file_spec(target_seqs)
-    query_specs = parse_file_spec(query_seqs)
-    v(f"Target specs: {target_specs} | Query specs: {query_specs}")
+        reference_specs = parse_file_spec(parse_seq_arg(args.reference, tmp_dir))
+        query_specs = parse_file_spec(parse_seq_arg(args.query, tmp_dir))
+        LOGGER.debug("Reference specs: %s", reference_specs)
+        LOGGER.debug("Query specs: %s", query_specs)
 
-    # v0 .2bit (≤4 GB): lastz reads natively via "<file>/<chrom>[start,end][multiple]".
-    # v1 .2bit (>4 GB, faToTwoBit -long): lastz can't read it. Use a pre-extracted
-    # per-chrom FASTA from --target_chrom_dir / --query_chrom_dir if provided
-    # (shared across tasks via EXTRACT_CHROMS) and fall back to a per-task
-    # extraction otherwise. Either way the resulting FASTA has a bare ">chrom"
-    # header, so lastz produces identical names and absolute coordinates.
-    side_chrom_dirs = {"target": args.target_chrom_dir, "query": args.query_chrom_dir}
-    for label, specs in (("target", target_specs), ("query", query_specs)):
-        path, chrom, start, end = specs
-        if chrom is None or not path.endswith(".2bit"):
-            continue
-        if not is_2bit_v1(path):
-            continue
-        if tmp_dir is None:
-            tmp_dir = get_temp_dir(pipeline_params.get("temp_dir"))
-            temp_is_needed = True
-        fasta_path = extract_chrom_to_fasta(
-            path, chrom, tmp_dir, shared_chrom_dir=side_chrom_dirs[label]
+        chrom_dirs = {
+            "reference": args.reference_chrom_dir,
+            "query": args.query_chrom_dir,
+        }
+        for label, specs in (("reference", reference_specs), ("query", query_specs)):
+            path, chrom, start, end = specs
+            if chrom is None or not path.endswith(".2bit") or not is_2bit_v1(path):
+                continue
+            if tmp_dir is None:
+                tmp_dir = get_temp_dir(temp_parent)
+            fasta_path = extract_chrom_to_fasta(path, chrom, chrom_dirs[label])
+            LOGGER.debug("Resolved v1 %s chromosome to FASTA: %s", label, fasta_path)
+            resolved_specs = (fasta_path, chrom, start, end)
+            if label == "reference":
+                reference_specs = resolved_specs
+            else:
+                query_specs = resolved_specs
+
+        define_if_not(pipeline_params, "lastz_h", 2000)
+        blastz_options = get_blastz_params(pipeline_params)
+        LOGGER.debug("LASTZ options: %s", blastz_options)
+        lastz_output = call_lastz(
+            build_lastz_command(reference_specs, query_specs, blastz_options)
         )
-        v(f"Resolved v1 {label} chrom to FASTA: {fasta_path}")
-        new_specs = (fasta_path, chrom, start, end)
-        if label == "target":
-            target_specs = new_specs
+
+        if check_if_output_is_non_empty(lastz_output):
+            output_to_save = make_psl_if_needed(
+                lastz_output,
+                args.output_format,
+                reference_sizes_path,
+                query_sizes_path,
+                args.axt_to_psl,
+            )
+            LOGGER.debug("Appending alignment output to: %s", args.output)
+            with open(args.output, "a") as output_file:
+                output_file.write(output_to_save)
         else:
-            query_specs = new_specs
-
-    define_if_not(pipeline_params, "lastz_h", 2000)
-    blastz_options = get_blastz_params(pipeline_params)
-    v(f"LASTZ options: {blastz_options}")
-
-    cmd = build_lastz_command(target_specs, query_specs, blastz_options)
-    v(f"Lastz command: {cmd}")
-    lastz_output = call_lastz(cmd)
-    output_is_non_empty = check_if_output_is_non_empty(lastz_output)
-
-    if output_is_non_empty is True:
-        out_to_save = make_psl_if_needed(
-            lastz_output,
-            args.output_format,
-            seq_1_sizes_path,
-            seq_2_sizes_path,
-            args.axt_to_psl,
-            v,
-        )
-        f = open(args.output, "a")
-        f.write(out_to_save)
-        f.close()
-    # else -> output is empty -> do not save an output file -> no need
-    if temp_is_needed:  # remove temp file if was used
-        shutil.rmtree(tmp_dir) if os.path.isdir(tmp_dir) else None
+            LOGGER.debug("LASTZ output contains no alignment records; no file written")
+    finally:
+        if tmp_dir and os.path.isdir(tmp_dir):
+            LOGGER.debug("Removing temporary workspace: %s", tmp_dir)
+            shutil.rmtree(tmp_dir)
 
 
 if __name__ == "__main__":

--- a/bin/run_lastz_intermediate_layer.py
+++ b/bin/run_lastz_intermediate_layer.py
@@ -1,142 +1,220 @@
 #!/usr/bin/env python3
-"""Intermediate layer to run LASTZ wrapper.
-
-Needed to process the case if many little scaffolds are to be aligned
-withing one cluster job."""
+"""Expand LASTZ BULK partitions and invoke the single-alignment wrapper."""
 
 import argparse
-import subprocess
-import sys
 import json
+import logging
+import os
+import shlex
+import subprocess
 from itertools import product
+from typing import Sequence
+
+LOGGER = logging.getLogger("run_lastz_intermediate_layer")
+
+__author__ = "Alejandro Gonzales-Irribarren"
+__credits__ = ["Bogdan M. Kirilenko, Nil Tianchen Mu"]
+__email__ = "alejandrxgzi@gmail.com"
+__github__ = "https://github.com/hillerlab/make_lastz_chains"
+__version__ = "0.0.2"
+
+PipelineParams = dict[str, object]
 
 
-def read_chrom_sizes(chrom_sizes_path):
-    """Read chrom.sizes file."""
-    chrom_sizes = {}
-    f = open(chrom_sizes_path, "r")
-    for line in f:
-        line_data = line.rstrip().split("\t")
-        chrom = line_data[0]
-        chrom_size = int(line_data[1])
-        chrom_sizes[chrom] = chrom_size
-    f.close()
+def configure_logging(verbose: bool) -> None:
+    """Enable concise stderr diagnostics when verbose logging is requested."""
+    logging.basicConfig(format="%(levelname)s %(name)s: %(message)s")
+    LOGGER.setLevel(logging.DEBUG if verbose else logging.WARNING)
+
+
+def read_chrom_sizes(chrom_sizes_path: str) -> dict[str, int]:
+    """Read chromosome lengths from a tab-separated chrom.sizes file."""
+    chrom_sizes: dict[str, int] = {}
+    with open(chrom_sizes_path) as chrom_sizes_file:
+        for line_number, line in enumerate(chrom_sizes_file, start=1):
+            line_data = line.rstrip().split("\t")
+            if len(line_data) != 2:
+                raise ValueError(
+                    f"Malformed chrom.sizes row {line_number} in {chrom_sizes_path}: "
+                    f"expected 2 tab-separated fields, got {len(line_data)}"
+                )
+            chrom, size = line_data
+            try:
+                chrom_sizes[chrom] = int(size)
+            except ValueError as error:
+                raise ValueError(
+                    f"Malformed chromosome size on row {line_number} in "
+                    f"{chrom_sizes_path}: {size!r}"
+                ) from error
     return chrom_sizes
 
 
-def read_json_file(file_path):
-    with open(file_path, "r") as f:
-        return json.load(f)  # TODO: move to commons
+def read_json_file(file_path: str) -> PipelineParams:
+    """Read and validate a pipeline-parameter JSON object."""
+    with open(file_path) as json_file:
+        data = json.load(json_file)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a JSON object in {file_path}")
+    return data
 
 
-def parse_args():
-    """Parse arguments.
+def require_string_param(params: PipelineParams, key: str) -> str:
+    """Return a required string parameter with a clear validation error."""
+    value = params.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"Pipeline parameter {key!r} must be a string")
+    return value
 
-    Recapitulates run_lastz.py parameters."""
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the explicit intermediate-wrapper command-line interface."""
     app = argparse.ArgumentParser()
-    app.add_argument("target", help="Target: single sequence file or .lst")
-    app.add_argument("query", help="Query: single sequence file or .lst")
-    app.add_argument("params_json", help="pipeline configuration file")
-    app.add_argument("output", help="Output file location")
-    app.add_argument("run_lastz_script", help="Path to the run_lastz script")
-
     app.add_argument(
-        "--output_format", choices=["psl", "axt"], help="Output format axt|psl"
+        "--reference",
+        required=True,
+        help="Reference: single sequence file or BULK partition",
+    )
+    app.add_argument(
+        "--query", required=True, help="Query: single sequence file or BULK partition"
+    )
+    app.add_argument(
+        "--params_json", required=True, help="Pipeline configuration JSON file"
+    )
+    app.add_argument("--output", required=True, help="Output file location")
+    app.add_argument(
+        "--run_lastz_script", required=True, help="Path to the run_lastz.py script"
+    )
+    app.add_argument(
+        "--output_format",
+        required=True,
+        choices=["psl", "axt"],
+        help="Output format: axt or psl",
     )
     app.add_argument(
         "--temp_dir",
-        help="Temp directory to save intermediate fasta files (if needed)\n"
-        "/tmp/ is default, however, params_json key TMPDIR can provide a value"
-        "the command line argument has a higher priority than DEF file",
+        help="Optional parent directory for temporary wrapper workspaces",
     )
     app.add_argument(
         "--verbose",
         "-v",
         action="store_true",
-        dest="verbose",
-        help="Show verbosity messages",
+        help="Log expanded partitions and subprocess commands to stderr",
     )
     app.add_argument(
         "--axt_to_psl",
         default="axtToPsl",
-        help="If axtToPsl is not in the path, use this"
-        "argument to provide path to this binary, if needed",
+        help="Path to axtToPsl if it is not available on PATH",
     )
     app.add_argument(
-        "--target_chrom_dir",
+        "--reference_chrom_dir",
         default=None,
-        help="Optional directory of pre-extracted <chrom>.fa files for the target genome. "
-        "Used to skip per-task v1 .2bit extraction in run_lastz.py.",
+        help="Optional directory of pre-extracted <chrom>.fa files for the reference genome",
     )
     app.add_argument(
         "--query_chrom_dir",
         default=None,
-        help="Optional directory of pre-extracted <chrom>.fa files for the query genome.",
+        help="Optional directory of pre-extracted <chrom>.fa files for the query genome",
+    )
+    return app.parse_args(argv)
+
+
+def get_intervals_list(to_align_arg: str, chrom_sizes: dict[str, int]) -> list[str]:
+    """Expand a BULK partition into ranged chromosome arguments."""
+    if not to_align_arg.startswith("BULK"):
+        return [to_align_arg]
+
+    arg_parts = to_align_arg.split(":")
+    if len(arg_parts) < 3:
+        raise ValueError(
+            f"Malformed BULK partition {to_align_arg!r}: expected BULK name, .2bit path, "
+            "and at least one chromosome"
+        )
+
+    two_bit_path = arg_parts[1]
+    intervals: list[str] = []
+    for chrom in arg_parts[2:]:
+        try:
+            end = chrom_sizes[chrom]
+        except KeyError as error:
+            raise ValueError(
+                f"Chromosome {chrom!r} from BULK partition {to_align_arg!r} "
+                "is missing from chrom.sizes"
+            ) from error
+        intervals.append(f"{two_bit_path}:{chrom}:0-{end}")
+    return intervals
+
+
+def build_lastz_command(
+    args: argparse.Namespace,
+    reference_arg: str,
+    query_arg: str,
+    params_json_path: str,
+) -> list[str]:
+    """Build one run_lastz.py subprocess command."""
+    command = [
+        args.run_lastz_script,
+        "--reference",
+        reference_arg,
+        "--query",
+        query_arg,
+        "--params_json",
+        params_json_path,
+        "--output",
+        args.output,
+        "--output_format",
+        args.output_format,
+        "--axt_to_psl",
+        args.axt_to_psl,
+    ]
+    if args.temp_dir:
+        command.extend(["--temp_dir", args.temp_dir])
+    if args.reference_chrom_dir:
+        command.extend(["--reference_chrom_dir", args.reference_chrom_dir])
+    if args.query_chrom_dir:
+        command.extend(["--query_chrom_dir", args.query_chrom_dir])
+    if args.verbose:
+        command.append("--verbose")
+    return command
+
+
+def run_lastz_command(command: list[str]) -> None:
+    """Run one child wrapper and fail immediately if it exits non-zero."""
+    LOGGER.debug("Running subprocess: %s", shlex.join(command))
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(
+            f"run_lastz.py subprocess failed with exit code {error.returncode}: "
+            f"{shlex.join(command)}"
+        ) from error
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Expand input partitions and run every reference-query combination."""
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+    params_json_path = os.path.abspath(args.params_json)
+    LOGGER.debug("Working directory: %s", os.getcwd())
+    LOGGER.debug("Pipeline params JSON: %s", params_json_path)
+
+    pipeline_params = read_json_file(params_json_path)
+    reference_chrom_sizes = read_chrom_sizes(
+        require_string_param(pipeline_params, "seq_1_len")
+    )
+    query_chrom_sizes = read_chrom_sizes(
+        require_string_param(pipeline_params, "seq_2_len")
+    )
+    reference_coordinates = get_intervals_list(args.reference, reference_chrom_sizes)
+    query_coordinates = get_intervals_list(args.query, query_chrom_sizes)
+    LOGGER.debug(
+        "Expanded partitions: %d reference interval(s) x %d query interval(s)",
+        len(reference_coordinates),
+        len(query_coordinates),
     )
 
-    if len(sys.argv) < 5:
-        app.print_help()
-        sys.exit(0)
-    args = app.parse_args()
-    return args
-
-
-def get_intervals_list(to_ali_arg, chrom_sizes):
-    """For bulk partitions argument, create a list of chromosomes
-    to feed into the LASTZ wrapper command.
-    """
-    ret = []
-    if not to_ali_arg.startswith("BULK"):
-        return [to_ali_arg]
-    arg_split = to_ali_arg.split(":")
-    two_bit_path = arg_split[1]
-    chroms_to_be_aligned_in_bulk = arg_split[2:]
-    for chrom in chroms_to_be_aligned_in_bulk:
-        _start = 0
-        _end = chrom_sizes[chrom]
-        upd_arg = f"{two_bit_path}:{chrom}:{_start}-{_end}"
-        ret.append(upd_arg)
-    return ret
-
-
-def main():
-    args = parse_args()
-    pipeline_params = read_json_file(args.params_json)
-    seq_1_sizes_path = pipeline_params["seq_1_len"]
-    seq_2_sizes_path = pipeline_params["seq_2_len"]
-    target_chrom_sizes = read_chrom_sizes(seq_1_sizes_path)
-    query_chrom_sizes = read_chrom_sizes(seq_2_sizes_path)
-    target_coordinates = get_intervals_list(args.target, target_chrom_sizes)
-    query_coordinates = get_intervals_list(args.query, query_chrom_sizes)
-
-    # for each combination of target and query partitions in this
-    # particular command, create and run the respective run_lastz.py command
-    # normally, it's just a single:
-    # reference chr 1 from 0 to 100000 vs query chr 2 1000000 to 3000000
-    # but in case some little scaffolds were aggregated, it must be unfolded first.
-    for target_arg, query_arg in product(target_coordinates, query_coordinates):
-        lastz_cmd = [
-            args.run_lastz_script,
-            target_arg,
-            query_arg,
-            args.params_json,
-            args.output,
-            "--output_format",
-            args.output_format,
-        ]
-        if args.temp_dir:
-            lastz_cmd.append(f"--temp_dir")
-            lastz_cmd.append(args.temp_dir)
-        if args.axt_to_psl:
-            lastz_cmd.append(f"--axt_to_psl")
-            lastz_cmd.append(args.axt_to_psl)
-        if args.target_chrom_dir:
-            lastz_cmd.append("--target_chrom_dir")
-            lastz_cmd.append(args.target_chrom_dir)
-        if args.query_chrom_dir:
-            lastz_cmd.append("--query_chrom_dir")
-            lastz_cmd.append(args.query_chrom_dir)
-        subprocess.call(lastz_cmd)
+    for reference_arg, query_arg in product(reference_coordinates, query_coordinates):
+        command = build_lastz_command(args, reference_arg, query_arg, params_json_path)
+        run_lastz_command(command)
 
 
 if __name__ == "__main__":

--- a/bin/tests/test_run_lastz_wrappers.py
+++ b/bin/tests/test_run_lastz_wrappers.py
@@ -1,0 +1,268 @@
+"""Regression tests for the LASTZ wrapper scripts."""
+
+import io
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager, redirect_stderr
+from pathlib import Path
+from typing import Iterator
+from unittest import mock
+
+BIN_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BIN_DIR))
+
+import run_lastz  # noqa: E402
+import run_lastz_intermediate_layer as intermediate  # noqa: E402
+
+
+@contextmanager
+def changed_directory(path: Path) -> Iterator[None]:
+    """Temporarily change the current working directory."""
+    previous_directory = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous_directory)
+
+
+def write_pipeline_inputs(directory: Path) -> Path:
+    """Write minimal chromosome-size and parameter files for wrapper tests."""
+    (directory / "reference.chrom.sizes").write_text("ref_a\t10\nref_b\t20\n")
+    (directory / "query.chrom.sizes").write_text("query_a\t30\nquery_b\t40\n")
+    params_path = directory / "params.json"
+    params_path.write_text(
+        json.dumps(
+            {
+                "seq_1_len": "reference.chrom.sizes",
+                "seq_2_len": "query.chrom.sizes",
+                "lastz_k": 2400,
+            }
+        )
+    )
+    return params_path
+
+
+class IntermediateLayerTests(unittest.TestCase):
+    """Cover BULK expansion and child-wrapper execution."""
+
+    def test_expands_regular_and_bulk_arguments(self) -> None:
+        """Expand BULK partitions without changing regular arguments."""
+        self.assertEqual(
+            intermediate.get_intervals_list("reference.2bit:chr1:0-10", {}),
+            ["reference.2bit:chr1:0-10"],
+        )
+        self.assertEqual(
+            intermediate.get_intervals_list(
+                "BULK_1:reference.2bit:ref_a:ref_b",
+                {"ref_a": 10, "ref_b": 20},
+            ),
+            ["reference.2bit:ref_a:0-10", "reference.2bit:ref_b:0-20"],
+        )
+
+    def test_reports_missing_bulk_chromosome(self) -> None:
+        """Reject BULK entries that are absent from chrom.sizes."""
+        with self.assertRaisesRegex(ValueError, "missing from chrom.sizes"):
+            intermediate.get_intervals_list("BULK_1:reference.2bit:missing", {})
+
+    def test_reports_malformed_chrom_sizes_rows(self) -> None:
+        """Reject malformed chromosome-size rows with file context."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sizes_path = Path(temp_dir) / "bad.chrom.sizes"
+            sizes_path.write_text("chr1 10\n")
+            with self.assertRaisesRegex(ValueError, "expected 2 tab-separated fields"):
+                intermediate.read_chrom_sizes(str(sizes_path))
+
+    def test_forwards_absolute_params_and_logs_bulk_commands(self) -> None:
+        """Forward absolute params paths and log every expanded subprocess."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            params_path = write_pipeline_inputs(directory)
+            log_output = io.StringIO()
+            handler = logging.StreamHandler(log_output)
+            intermediate.LOGGER.addHandler(handler)
+            try:
+                with (
+                    changed_directory(directory),
+                    mock.patch.object(intermediate.subprocess, "run") as run,
+                ):
+                    intermediate.main(
+                        [
+                            "--reference",
+                            "BULK_1:reference.2bit:ref_a:ref_b",
+                            "--query",
+                            "BULK_2:query.2bit:query_a:query_b",
+                            "--params_json",
+                            params_path.name,
+                            "--output",
+                            "out.psl",
+                            "--run_lastz_script",
+                            "run_lastz.py",
+                            "--output_format",
+                            "psl",
+                            "--reference_chrom_dir",
+                            "reference_chroms",
+                            "--query_chrom_dir",
+                            "query_chroms",
+                            "--verbose",
+                        ]
+                    )
+            finally:
+                intermediate.LOGGER.removeHandler(handler)
+
+            self.assertEqual(run.call_count, 4)
+            for call in run.call_args_list:
+                command = call.args[0]
+                self.assertEqual(call.kwargs, {"check": True})
+                params_index = command.index("--params_json") + 1
+                self.assertEqual(command[params_index], str(params_path.resolve()))
+                self.assertIn("--reference_chrom_dir", command)
+                self.assertIn("--query_chrom_dir", command)
+                self.assertIn("--verbose", command)
+
+            logs = log_output.getvalue()
+            self.assertIn(
+                "Expanded partitions: 2 reference interval(s) x 2 query interval(s)",
+                logs,
+            )
+            self.assertEqual(logs.count("Running subprocess:"), 4)
+
+    def test_does_not_log_commands_without_verbose(self) -> None:
+        """Suppress subprocess diagnostics unless --verbose is passed."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            params_path = write_pipeline_inputs(directory)
+            log_output = io.StringIO()
+            handler = logging.StreamHandler(log_output)
+            intermediate.LOGGER.addHandler(handler)
+            try:
+                with (
+                    changed_directory(directory),
+                    mock.patch.object(intermediate.subprocess, "run"),
+                ):
+                    intermediate.main(
+                        [
+                            "--reference",
+                            "reference.2bit:ref_a:0-10",
+                            "--query",
+                            "query.2bit:query_a:0-30",
+                            "--params_json",
+                            params_path.name,
+                            "--output",
+                            "out.psl",
+                            "--run_lastz_script",
+                            "run_lastz.py",
+                            "--output_format",
+                            "psl",
+                        ]
+                    )
+            finally:
+                intermediate.LOGGER.removeHandler(handler)
+            self.assertEqual(log_output.getvalue(), "")
+
+    def test_propagates_child_failure(self) -> None:
+        """Abort when a child run_lastz.py process exits non-zero."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            params_path = write_pipeline_inputs(directory)
+            failure = subprocess.CalledProcessError(7, ["run_lastz.py"])
+            with (
+                changed_directory(directory),
+                mock.patch.object(intermediate.subprocess, "run", side_effect=failure),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "exit code 7"):
+                    intermediate.main(
+                        [
+                            "--reference",
+                            "reference.2bit:ref_a:0-10",
+                            "--query",
+                            "query.2bit:query_a:0-30",
+                            "--params_json",
+                            params_path.name,
+                            "--output",
+                            "out.psl",
+                            "--run_lastz_script",
+                            "run_lastz.py",
+                            "--output_format",
+                            "psl",
+                        ]
+                    )
+
+    def test_rejects_positional_interface(self) -> None:
+        """Reject the historical positional command-line interface."""
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            intermediate.parse_args(
+                ["reference", "query", "params", "output", "script"]
+            )
+
+
+class RunLastzTests(unittest.TestCase):
+    """Cover single-alignment wrapper helpers and cleanup."""
+
+    def test_builds_existing_sequence_argument_forms(self) -> None:
+        """Preserve ranged and whole-file LASTZ argument construction."""
+        self.assertEqual(
+            run_lastz._seq_arg("ref.fa", None, None, None), '"ref.fa[multiple]"'
+        )
+        self.assertEqual(
+            run_lastz._seq_arg("ref.2bit", "chr1", 0, 10),
+            '"ref.2bit/chr1[1,10][multiple]"',
+        )
+        self.assertEqual(
+            run_lastz._seq_arg("ref.fa", "chr1", 0, 10),
+            '"ref.fa[1,10][multiple]"',
+        )
+
+    def test_reports_malformed_sequence_spec(self) -> None:
+        """Reject malformed ranged sequence arguments with context."""
+        with self.assertRaisesRegex(ValueError, "Malformed sequence argument"):
+            run_lastz.parse_file_spec("reference.2bit:chr1:not-a-range")
+
+    def test_removes_owned_temp_workspace_but_preserves_parent(self) -> None:
+        """Delete generated workspaces without deleting a caller-owned parent."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            temp_parent = directory / "temp_parent"
+            temp_parent.mkdir()
+            sentinel = temp_parent / "keep.txt"
+            sentinel.write_text("keep")
+            (directory / "reference.lst").write_text("reference.fa\n")
+            params_path = write_pipeline_inputs(directory)
+
+            with (
+                changed_directory(directory),
+                mock.patch.object(run_lastz, "call_lastz", return_value=""),
+            ):
+                run_lastz.main(
+                    [
+                        "--reference",
+                        "reference.lst",
+                        "--query",
+                        "query.fa",
+                        "--params_json",
+                        params_path.name,
+                        "--output",
+                        "out.axt",
+                        "--output_format",
+                        "axt",
+                        "--temp_dir",
+                        str(temp_parent),
+                    ]
+                )
+
+            self.assertTrue(sentinel.exists())
+            self.assertEqual(list(temp_parent.iterdir()), [sentinel])
+
+    def test_rejects_positional_interface(self) -> None:
+        """Reject the historical positional command-line interface."""
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            run_lastz.parse_args(["reference", "query", "params", "output"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/local/lastz/main.nf
+++ b/modules/local/lastz/main.nf
@@ -1,13 +1,13 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    LASTZ — Pairwise sequence alignment for one target × query partition pair
+    LASTZ — Pairwise sequence alignment for one reference × query partition pair
     Uses run_lastz_intermediate_layer.py (from standalone_scripts/) to handle
     both regular and BULK partitions. A minimal params JSON is written per job.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
 process LASTZ {
-    tag "${target_part} vs ${query_part}"
+    tag "${reference_part} vs ${query_part}"
     label 'process_fast'
 
     conda "${moduleDir}/environment.yml"
@@ -16,12 +16,12 @@ process LASTZ {
         'ghcr.io/hillerlab/pylastz:latest' }"
 
     input:
-    tuple val(target_part), val(query_part)
-    path  target_twobit                     // staged as its basename, e.g. target.2bit
+    tuple val(reference_part), val(query_part)
+    path  reference_twobit                     // staged as its basename, e.g. reference.2bit
     path  query_twobit
-    path  target_chrom_sizes
+    path  reference_chrom_sizes
     path  query_chrom_sizes
-    path  target_chroms_dir                 // dir of pre-extracted <chrom>.fa (v1) or empty (v0)
+    path  reference_chroms_dir                 // dir of pre-extracted <chrom>.fa (v1) or empty (v0)
     path  query_chroms_dir
     val   lastz_k
     val   lastz_h
@@ -29,7 +29,7 @@ process LASTZ {
     val   lastz_y
 
     output:
-    tuple val(target_part), path("*.psl"), optional: true, emit: psl
+    tuple val(reference_part), path("*.psl"), optional: true, emit: psl
     path  "versions.yml",                                   emit: versions
 
     script:
@@ -45,14 +45,14 @@ process LASTZ {
         def parts = p.split(":")
         return "${parts[1]}_${parts[2]}"
     }
-    def t_safe = safe_part(target_part)
+    def t_safe = safe_part(reference_part)
     def q_safe = safe_part(query_part)
     def out_psl = "${t_safe}__${q_safe}.psl"
     """
     # Write minimal pipeline params JSON so run_lastz* scripts can read chrom.sizes
     cat > params.json << 'JSONEOF'
     {
-        "seq_1_len": "${target_chrom_sizes.name}",
+        "seq_1_len": "${reference_chrom_sizes.name}",
         "seq_2_len": "${query_chrom_sizes.name}",
         "lastz_k": ${lastz_k},
         "lastz_h": ${lastz_h},
@@ -62,13 +62,13 @@ process LASTZ {
     JSONEOF
 
     run_lastz_intermediate_layer.py \\
-        '${target_part}' \\
-        '${query_part}' \\
-        params.json \\
-        ${out_psl} \\
-        run_lastz.py \\
+        --reference '${reference_part}' \\
+        --query '${query_part}' \\
+        --params_json params.json \\
+        --output ${out_psl} \\
+        --run_lastz_script run_lastz.py \\
         --output_format psl \\
-        --target_chrom_dir ${target_chroms_dir} \\
+        --reference_chrom_dir ${reference_chroms_dir} \\
         --query_chrom_dir ${query_chroms_dir}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/partition/main.nf
+++ b/modules/local/partition/main.nf
@@ -13,7 +13,7 @@ process PARTITION {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.8.0--2' :
-        'biocontainers/python:3.8.0--2' }"
+        'biocontainers/python:3.11' }"
 
     input:
     tuple val(genome_name), path(twobit), path(chrom_sizes)

--- a/modules/local/psl_bundle/main.nf
+++ b/modules/local/psl_bundle/main.nf
@@ -12,7 +12,7 @@ process PSL_BUNDLE {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.8.0--2' :
-        'biocontainers/python:3.8.0--2' }"
+        'biocontainers/python:3.11' }"
 
     input:
     path sorted_psl_dir       // directory output of PSL_SORT_ACC

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,7 +35,7 @@ manifest {
     description     = 'Pipeline to create chain-formatted pairwise genome alignments.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=25.04.6'
-    version         = '3.1.2'
+    version         = '3.1.3'
 }
 
 validation {


### PR DESCRIPTION
Refactored the LASTZ alignment wrappers and completed the `target` → `reference` terminology migration across the alignment pipeline, alongside a Python container upgrade and internal code quality improvements.

This PR includes a bump to the correspondent v3.1.3 of [ghcr.io/hillerlab/make_lastz_chains:latest](https://github.com/hillerlab/containers/pkgs/container/make_lastz_chains).

### LASTZ wrapper rewrite

- Rewrote `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py` with structured logging via Python's `logging` module, comprehensive type annotations, and explicit input validation. The older `verbose_msg` lambda pattern has been replaced with proper `LOGGER.debug()` calls throughout.
- Migrated both scripts from positional CLI arguments to explicit `--flag value` options (`--reference`, `--query`, `--params_json`, `--output`, etc.), making the command-line interface self-documenting and consistent with the rest of the pipeline's entry points.
- Added proper resource management — temporary workspace cleanup now uses `try/finally` blocks, ensuring temporary directories are removed even when a subprocess fails.
- Introduced validated parameter access via `require_string_param` in both scripts, surfacing clear error messages when mandatory pipeline configuration keys are missing or malformed.
- Added BULK partition validation in `run_lastz_intermediate_layer.py` to catch malformed partition entries early, and replaced `subprocess.call` with `subprocess.run` + `check=True` for immediate error propagation on child failures.

This covers the following error:

```
      ... \
      ... \
      params.json \
      BULK_10__BULK_1.psl \
      run_lastz.py \
      --output_format psl \
      --target_chrom_dir hg38_chroms \
      --query_chrom_dir mm39_chroms
  
  cat <<-END_VERSIONS > versions.yml
  "MAKE_LASTZ_CHAINS:FULL_RUN:CHAINS:LASTZ_ALIGNMENT:LASTZ":
      lastz: $(lastz --version 2>&1 | head -1)
      python: $(python --version 2>&1 | awk '{print $2}')
      axtToPsl: 482
  END_VERSIONS

Command exit status:
  1

Command output:
  (empty)

Command wrapper:
    File "/usr/local/bin/run_lastz.py", line 458, in <module>
      main()
    File "/usr/local/bin/run_lastz.py", line 387, in main
      pipeline_params = read_json_file(args.params_json)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/bin/run_lastz.py", line 124, in read_json_file
      with open(file_path, "r") as f:
           ^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: 'params.json'
  Traceback (most recent call last):
    File "/usr/local/bin/run_lastz.py", line 458, in <module>
      main()
    File "/usr/local/bin/run_lastz.py", line 387, in main
      pipeline_params = read_json_file(args.params_json)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Terminology completion (`target` → `reference`)

- Renamed the `--target` CLI argument to `--reference` and `--target_chrom_dir` to `--reference_chrom_dir` in both `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py`, including all associated variables, function parameters, and documentation strings.
- Updated `modules/local/lastz/main.nf` to use `reference_part`, `reference_twobit`, `reference_chrom_sizes`, and `reference_chroms_dir` throughout, and aligned the underlying `run_lastz*` script invocations with the new `--reference` and `--reference_chrom_dir` flags.
- Harmonised process tags and output channel naming with the new terminology, completing the glossary update that began in v3.1.0.

### Python container upgrade

- Updated the `PARTITION` and `PSL_BUNDLE` process containers from `biocontainers/python:3.8.0--2` to `biocontainers/python:3.11`. Both modules now run on Python 3.11, matching the runtime version used elsewhere in the pipeline.

### Type hints and documentation

- Added full type annotations and docstrings to `bin/partition.py` and `bin/psl_bundle.py` — function signatures now declare argument and return types, constants carry explicit type declarations, and every public function includes a descriptive docstring.
- Added script-level metadata (`__author__`, `__credits__`, `__email__`, `__github__`, `__version__`) to `bin/run_lastz.py` and `bin/run_lastz_intermediate_layer.py`.

### Config adjustments

- Bumped manifest version from `3.1.2` to `3.1.3`.