### PR TITLE
fix: add process label to chaintools merge

### DIFF
--- a/modules/local/chaintools/merge/main.nf
+++ b/modules/local/chaintools/merge/main.nf
@@ -13,6 +13,7 @@ Distributed under the terms of the Apache License, Version 2.0.
 
 process CHAINTOOLS_MERGE {
     tag "$meta.id"
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Solves #124 

```
#!/bin/bash
#SBATCH -J nf-MAKE_LASTZ_CHAINS_FULL_RUN_CHAINS_CHAIN_BUILD_CHAINTOOLS_MERGE_(test_ref.test_query)
#SBATCH -o make_lastz_chains/work/26/4eb93b87c803cf05a9fdfdf84d52f2/.command.log
#SBATCH --no-requeue
#SBATCH -t 02:00:00
#SBATCH --mem 51200M
#SBATCH -p batch
#SBATCH --signal=USR2@180 --export=ALL,SLURM_SKIP_EPILOG=1
NXF_CHDIR=.
### ---
### name: 'MAKE_LASTZ_CHAINS:FULL_RUN:CHAINS:CHAIN_BUILD:CHAINTOOLS_MERGE (test_ref.test_query)'
### container: 'ghcr.io-hillerlab-make_lastz_chains-latest.img'
### outputs:
### - '*.all.chain'
### - '*.all.chain.gz'
### - 'versions.yml'
### ...
```