### PR TITLE
docs: add command-line parameter example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ nextflow run main.nf -params-file params.json -profile docker
 nextflow run main.nf -params-file params.json -profile apptainer
 ```
 
+Alternatively, keep the alignment settings in `params.json` and provide the genome paths and output directory as command-line arguments:
+
+```bash
+nextflow run main.nf -params-file params.json -profile docker \
+    --reference_genome /path/to/reference.2bit \
+    --query_genome /path/to/query.2bit \
+    --outdir results
+```
+
+Command-line parameters override matching values from `params.json`; all other parameters continue to come from the file.
+
 > [!TIP]
 > We recommend running the pipeline test suite with:
 > ```bash


### PR DESCRIPTION
This PR documents that reference_genome, query_genome, and outdir can be supplied directly on the command line while retaining shared LASTZ and chaining settings in params.json.
This is convenient when running multiple genome pairs: users can reuse one parameter file for consistent alignment settings while keeping each command’s inputs and output location explicit. Command-line values override matching entries in params.json.